### PR TITLE
Update CI workflow file

### DIFF
--- a/.github/workflows/CI-pipeline.yml
+++ b/.github/workflows/CI-pipeline.yml
@@ -16,7 +16,6 @@ name: CI-pipeline
 on:
   push:
     branches:
-      - master
       - develop
   pull_request:
 


### PR DESCRIPTION
Update CI workflow to prevent triggering when merging into `master` branch.
The main purpose - decrease execution time for CI builds.
There is no need to run such checks because they will be performed with PR.