### PR TITLE
Use screenshot path from cypress config

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -144,14 +144,15 @@ class Reporter {
           level,
           time: new Date().valueOf(),
         },
-        getFailedScreenshot(test.title),
+        getFailedScreenshot(this.config.screenshotsFolder, test.title),
       ).promise;
       promiseErrorHandler(sendFailedLogPromise, 'Fail to save error log');
     }
-    const passedScreenshots = getPassedScreenshots(test.title);
+    const passedScreenshots = getPassedScreenshots(this.config.screenshotsFolder, test.title);
     const customScreenshots = getCustomScreenshots(
-      this.currentTestCustomScreenshots,
+      this.config.screenshotsFolder,
       test.testFileName,
+      this.currentTestCustomScreenshots,
     );
 
     passedScreenshots.concat(customScreenshots).forEach((file) => {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -33,7 +33,8 @@ const getCustomScreenshots = (screenshotsPath, specFilePath, customScreenshotsFi
 
   const specFileName = path.parse(specFilePath).base;
   return customScreenshotsFileNames.reduce((screenshots, screenshotFilename) => {
-    const screenshotFiles = glob.sync(`${screenshotsPath}/**/${specFileName}/${screenshotFilename}.png`) || [];
+    const screenshotFiles =
+      glob.sync(`${screenshotsPath}/**/${specFileName}/${screenshotFilename}.png`) || [];
     if (screenshotFiles.length) {
       return screenshots.concat([
         {
@@ -49,7 +50,10 @@ const getCustomScreenshots = (screenshotsPath, specFilePath, customScreenshotsFi
 
 const getPassedScreenshots = (screenshotsPath, testTitle) => {
   const patternFirstScreenshot = `${screenshotsPath}/**/*${testTitle.replace(/[",',:]/g, '')}.png`;
-  const patternNumeratedScreenshots = `${screenshotsPath}/**/*${testTitle.replace(/[",',:]/g, '')} (*([0-9])).png`;
+  const patternNumeratedScreenshots = `${screenshotsPath}/**/*${testTitle.replace(
+    /[",',:]/g,
+    '',
+  )} (*([0-9])).png`;
   const firstScreenshot = glob.sync(patternFirstScreenshot) || [];
   const numeratedScreenshots = glob.sync(patternNumeratedScreenshots) || [];
   const files = firstScreenshot.concat(numeratedScreenshots);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -28,12 +28,12 @@ const base64Encode = (file) => {
   return Buffer.from(bitmap).toString('base64');
 };
 
-const getCustomScreenshots = (customScreenshotsFileNames, specFilePath) => {
+const getCustomScreenshots = (screenshotsPath, specFilePath, customScreenshotsFileNames) => {
   if (!customScreenshotsFileNames.length) return [];
 
   const specFileName = path.parse(specFilePath).base;
   return customScreenshotsFileNames.reduce((screenshots, screenshotFilename) => {
-    const screenshotFiles = glob.sync(`**/${specFileName}/${screenshotFilename}.png`) || [];
+    const screenshotFiles = glob.sync(`${screenshotsPath}/**/${specFileName}/${screenshotFilename}.png`) || [];
     if (screenshotFiles.length) {
       return screenshots.concat([
         {
@@ -47,9 +47,9 @@ const getCustomScreenshots = (customScreenshotsFileNames, specFilePath) => {
   }, []);
 };
 
-const getPassedScreenshots = (testTitle) => {
-  const patternFirstScreenshot = `**/*${testTitle.replace(/[",',:]/g, '')}.png`;
-  const patternNumeratedScreenshots = `**/*${testTitle.replace(/[",',:]/g, '')} (*([0-9])).png`;
+const getPassedScreenshots = (screenshotsPath, testTitle) => {
+  const patternFirstScreenshot = `${screenshotsPath}/**/*${testTitle.replace(/[",',:]/g, '')}.png`;
+  const patternNumeratedScreenshots = `${screenshotsPath}/**/*${testTitle.replace(/[",',:]/g, '')} (*([0-9])).png`;
   const firstScreenshot = glob.sync(patternFirstScreenshot) || [];
   const numeratedScreenshots = glob.sync(patternNumeratedScreenshots) || [];
   const files = firstScreenshot.concat(numeratedScreenshots);
@@ -60,8 +60,8 @@ const getPassedScreenshots = (testTitle) => {
   }));
 };
 
-const getFailedScreenshot = (testTitle) => {
-  const pattern = `**/*${testTitle.replace(/[",',:]/g, '')} (failed).png`;
+const getFailedScreenshot = (screenshotsPath, testTitle) => {
+  const pattern = `${screenshotsPath}/**/*${testTitle.replace(/[",',:]/g, '')} (failed).png`;
   const files = glob.sync(pattern);
   return files.length
     ? {

--- a/test/mock/mock.js
+++ b/test/mock/mock.js
@@ -29,6 +29,7 @@ class RPClient {
 }
 
 const getDefaultConfig = () => ({
+  screenshotsFolder: 'example/screenshots',
   reporter: '@reportportal/agent-js-cypress',
   reporterOptions: {
     token: '00000000-0000-0000-0000-000000000000',

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -42,6 +42,7 @@ describe('utils script', () => {
     });
 
     it('getFailedScreenshot: should return failed attachment', () => {
+      const screenshotsPath = 'example\\screenshots';
       const testTitle = 'test name';
       const expectedAttachment = {
         name: 'test name (failed)',
@@ -49,13 +50,14 @@ describe('utils script', () => {
         content: Buffer.from([8, 6, 7, 5, 3, 0, 9]).toString('base64'),
       };
 
-      const attachment = getFailedScreenshot(testTitle);
+      const attachment = getFailedScreenshot(screenshotsPath, testTitle);
 
       expect(attachment).toBeDefined();
       expect(attachment).toEqual(expectedAttachment);
     });
 
     it('getPassedScreenshots: should return passed attachments', () => {
+      const screenshotsPath = 'example\\screenshots';
       const testTitle = 'test name';
       const expectedAttachments = [
         {
@@ -70,7 +72,7 @@ describe('utils script', () => {
         },
       ];
 
-      const attachments = getPassedScreenshots(testTitle);
+      const attachments = getPassedScreenshots(screenshotsPath, testTitle);
 
       expect(attachments).toBeDefined();
       expect(attachments.length).toEqual(2);
@@ -81,6 +83,7 @@ describe('utils script', () => {
       jest.spyOn(path, 'parse').mockImplementation(() => ({
         base: 'example.spec.js',
       }));
+      const screenshotsPath = 'example\\screenshots';
       const testFileName = `test\\example.spec.js`;
       const customScreenshotNames = ['customScreenshot1', 'customDir/customScreenshot2'];
       const expectedAttachments = [
@@ -96,7 +99,7 @@ describe('utils script', () => {
         },
       ];
 
-      const attachments = getCustomScreenshots(customScreenshotNames, testFileName);
+      const attachments = getCustomScreenshots(screenshotsPath, testFileName, customScreenshotNames);
 
       expect(attachments).toBeDefined();
       expect(attachments.length).toEqual(2);
@@ -108,10 +111,11 @@ describe('utils script', () => {
       jest.spyOn(path, 'parse').mockImplementation(() => ({
         base: 'example.spec.js',
       }));
+      const screenshotsPath = 'example\\screenshots';
       const testFileName = `test\\example.spec.js`;
       const customScreenshotNames = ['screenshotNotExist1', 'screenshotNotExist2'];
 
-      const attachments = getCustomScreenshots(customScreenshotNames, testFileName);
+      const attachments = getCustomScreenshots(screenshotsPath, testFileName, customScreenshotNames);
 
       expect(attachments).toBeDefined();
       expect(attachments.length).toEqual(0);

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -99,7 +99,11 @@ describe('utils script', () => {
         },
       ];
 
-      const attachments = getCustomScreenshots(screenshotsPath, testFileName, customScreenshotNames);
+      const attachments = getCustomScreenshots(
+        screenshotsPath,
+        testFileName,
+        customScreenshotNames,
+      );
 
       expect(attachments).toBeDefined();
       expect(attachments.length).toEqual(2);
@@ -115,7 +119,11 @@ describe('utils script', () => {
       const testFileName = `test\\example.spec.js`;
       const customScreenshotNames = ['screenshotNotExist1', 'screenshotNotExist2'];
 
-      const attachments = getCustomScreenshots(screenshotsPath, testFileName, customScreenshotNames);
+      const attachments = getCustomScreenshots(
+        screenshotsPath,
+        testFileName,
+        customScreenshotNames,
+      );
 
       expect(attachments).toBeDefined();
       expect(attachments.length).toEqual(0);


### PR DESCRIPTION
For #73

Looking at https://docs.cypress.io/api/commands/screenshot.html, cypress can only save screenshots to the folder set in the config. Only searching this folder should make it a lot quicker.