### PR TITLE
Reflect cypress 10 changes for getTotalSpecs

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -217,44 +217,56 @@ const getHookStartObject = (hook) => {
     codeRef: hook.codeRef,
   };
 };
+const getFixtureFolderPattern = (config) => {
+  return [].concat(config.fixturesFolder ? path.join(config.fixturesFolder, '**', '*') : []);
+};
 
-const getTotalSpecs = ({
-  ignoreTestFiles,
-  testFiles,
-  integrationFolder,
-  fixturesFolder,
-  supportFile,
-}) => {
-  const specConfig = Object.assign(
-    {},
-    DEFAULT_SPEC_CONFIG,
-    ignoreTestFiles && { ignoreTestFiles },
-    testFiles && { testFiles },
-    integrationFolder && { integrationFolder },
-    fixturesFolder && { fixturesFolder },
-    supportFile && { supportFile },
-  );
+const getExcludeSpecPattern = (config) => {
+  // Return cypress >= 10 pattern.
+  if (config.excludeSpecPattern) {
+    const excludePattern = Array.isArray(config.excludeSpecPattern)
+      ? config.excludeSpecPattern
+      : [config.excludeSpecPattern];
+    return [...excludePattern];
+  }
 
-  const fixturesFolderPath = path.join(specConfig.fixturesFolder, '**', '*');
+  // Return cypress <= 9 pattern
+  const ignoreTestFilesPattern = Array.isArray(config.ignoreTestFiles)
+    ? config.ignoreTestFiles
+    : [config.ignoreTestFiles] || [];
 
-  const supportFilePath = specConfig.supportFile || [];
+  return [...ignoreTestFilesPattern];
+};
+
+const getSpecPattern = (config) => {
+  if (config.specPattern) return [].concat(config.specPattern);
+
+  return Array.isArray(config.testFiles)
+    ? config.testFiles.map((file) => path.join(config.integrationFolder, file))
+    : [].concat(path.join(config.integrationFolder, config.testFiles));
+};
+
+const getTotalSpecs = (config) => {
+  if (!config.testFiles && !config.specPattern)
+    throw new Error('Configuration property not set! Neither for cypress <= 9 nor cypress >= 10');
+
+  const specPattern = getSpecPattern(config);
+
+  const excludeSpecPattern = getExcludeSpecPattern(config);
 
   const options = {
     sort: true,
     absolute: true,
     nodir: true,
-    cwd: specConfig.integrationFolder,
-    ignore: [supportFilePath, fixturesFolderPath],
+    ignore: [config.supportFile, path.join(config.fixturesFolder, '**', '*')],
   };
 
-  const ignorePatterns = [].concat(specConfig.ignoreTestFiles);
-
   const doesNotMatchAllIgnoredPatterns = (file) =>
-    ignorePatterns.every((pattern) => !minimatch(file, pattern, { dot: true, matchBase: true }));
+    excludeSpecPattern.every(
+      (pattern) => !minimatch(file, pattern, { dot: true, matchBase: true }),
+    );
 
-  const testFilesPatterns = [].concat(specConfig.testFiles);
-
-  const globResult = testFilesPatterns.reduce(
+  const globResult = specPattern.reduce(
     (files, pattern) => files.concat(glob.sync(pattern, options) || []),
     [],
   );
@@ -279,4 +291,7 @@ module.exports = {
   getHookStartObject,
   getTotalSpecs,
   getConfig,
+  getExcludeSpecPattern,
+  getFixtureFolderPattern,
+  getSpecPattern,
 };


### PR DESCRIPTION
Cypress 10 updated its configuration structure. Refactored the part to get the total number of specs for the run. Now the reporter should supports cypress 10. I had no further issues within our test repository.

The changes resulted in not finishing launches if eg. `autoMerge` options was used. To finish the launch the current and total number of specs needs to be equal. Due to different naming and removed properties in the config of cypress 10 the number of total specs got calculated wrong.

Refactored the method and add some helper functions.
Also extend the unit tests.

May solve this issue: #116 