### PR TITLE
Finish skipped tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ const updatedConfig = {
 
 ```
 
+For security reasons, you can also set token as a part of Environment Variables, instead of sharing it in the config file:
+
 **Overwrite by env variables:**
 
 | Parameter | Env variable |

--- a/README.md
+++ b/README.md
@@ -156,9 +156,7 @@ const updatedConfig = {
 
 ```
 
-For security reasons, you can also set token as a part of Environment Variables, instead of sharing it in the config file:
-
-**Overwrite by env variables:**
+**For security reasons, you can also set token as a part of Environment Variables, instead of sharing it in the config file:**
 
 | Parameter | Env variable |
 |-----------|--------------|

--- a/lib/cypressReporter.js
+++ b/lib/cypressReporter.js
@@ -145,8 +145,11 @@ class CypressReporter extends Mocha.reporters.Base {
     });
 
     this.runner.on(EVENT_TEST_PENDING, (test) => {
-      this.worker.send({ event: EVENT_TEST_PENDING, test: getTestInfo(test, this.runner.suite.file) });
-    })
+      this.worker.send({
+        event: EVENT_TEST_PENDING,
+        test: getTestInfo(test, this.runner.suite.file),
+      });
+    });
 
     this.runner.on(EVENT_RUN_END, () => {
       CypressReporter.calcTotalLaunches();

--- a/lib/cypressReporter.js
+++ b/lib/cypressReporter.js
@@ -26,6 +26,7 @@ const {
   EVENT_HOOK_BEGIN,
   EVENT_HOOK_END,
   EVENT_TEST_FAIL,
+  EVENT_TEST_PENDING,
 } = Mocha.Runner.constants;
 const { fork } = require('child_process');
 const { startIPCServer } = require('./ipcServer');
@@ -142,6 +143,10 @@ class CypressReporter extends Mocha.reporters.Base {
     this.runner.on(EVENT_TEST_END, (test) => {
       this.worker.send({ event: EVENT_TEST_END, test: getTestInfo(test, this.runner.suite.file) });
     });
+
+    this.runner.on(EVENT_TEST_PENDING, (test) => {
+      this.worker.send({ event: EVENT_TEST_PENDING, test: getTestInfo(test, this.runner.suite.file) });
+    })
 
     this.runner.on(EVENT_RUN_END, () => {
       CypressReporter.calcTotalLaunches();

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -55,6 +55,7 @@ class Reporter {
     this.suitesStackTempInfo = [];
     this.suiteTestCaseIds = new Map();
     this.currentTestCustomScreenshots = [];
+    this.pendingTestsIds = [];
     this.suiteStatuses = new Map();
   }
 
@@ -139,6 +140,9 @@ class Reporter {
     promiseErrorHandler(promise, 'Fail to start test');
     this.testItemIds.set(test.id, tempId);
     this.currentTestTempInfo = { tempId, startTime: startTestObj.startTime };
+    if (this.pendingTestsIds.includes(test.id)) {
+      this.testEnd(test);
+    }
   }
 
   sendLogOnFinishItem(test, tempTestId) {
@@ -191,6 +195,16 @@ class Reporter {
     promiseErrorHandler(finishTestItemPromise, 'Fail to finish test');
     this.resetCurrentTestFinishParams();
     this.currentTestTempInfo = null;
+  }
+
+  testPending(test) {
+    // if test has not been started, save test.id to finish in testStart().
+    // if testStarted() has been called, call testEnd() directly.
+    if (this.testItemIds.get(test.id) != null) {
+      this.testEnd(test);
+    } else {
+      this.pendingTestsIds.push(test.id);
+    }
   }
 
   hookStart(hook) {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -27,6 +27,7 @@ const {
   EVENT_SUITE_END,
   EVENT_HOOK_BEGIN,
   EVENT_HOOK_END,
+  EVENT_TEST_PENDING,
 } = Mocha.Runner.constants;
 
 const interval = setInterval(() => {}, 1000);
@@ -65,6 +66,9 @@ process.on('message', (message) => {
     case EVENT_TEST_END:
       reporter.testEnd(message.test);
       break;
+    case EVENT_TEST_PENDING:
+      reporter.testPending(message.test);
+      break;  
     case EVENT_HOOK_BEGIN:
       reporter.hookStart(message.hook);
       break;

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -68,7 +68,7 @@ process.on('message', (message) => {
       break;
     case EVENT_TEST_PENDING:
       reporter.testPending(message.test);
-      break;  
+      break;
     case EVENT_HOOK_BEGIN:
       reporter.hookStart(message.hook);
       break;

--- a/test/reporter.test.js
+++ b/test/reporter.test.js
@@ -411,6 +411,62 @@ describe('reporter script', () => {
       expect(spyFinishTestItem).toHaveBeenCalledWith('tempTestItemId', expectedTestFinishObj);
     });
   });
+
+  describe('testPending', function() {
+    it('testPending should call testEnd if test has been started', function() {
+      const spyTestEnd = jest.spyOn(reporter, 'testEnd');
+
+      const testInfoObject = {
+        id: 'testId',
+        title: 'test name',
+        status: 'skipped',
+        parentId: 'suiteId',
+      };
+
+      reporter.testItemIds.set(testInfoObject.id, 'tempid');
+      reporter.testPending(testInfoObject);
+
+      expect(spyTestEnd).toHaveBeenCalledTimes(1);
+      expect(spyTestEnd).toHaveBeenCalledWith(testInfoObject);
+    });
+
+    it('testPending should mark test as pending if not started', function() {
+      const spyTestEnd = jest.spyOn(reporter, 'testEnd');
+
+      const testInfoObject = {
+        id: 'testId',
+        title: 'test name',
+        status: 'skipped',
+        parentId: 'suiteId',
+      };
+
+      reporter.testPending(testInfoObject);
+
+      expect(spyTestEnd).not.toHaveBeenCalled();
+      expect(reporter.pendingTestsIds).toContainEqual(testInfoObject.id);
+    });
+
+    it('testStart should call testEnd if item is pending', function() {
+      const spyStartTestItem = jest.spyOn(reporter.client, 'startTestItem');
+      const spyTestEnd = jest.spyOn(reporter, 'testEnd');
+
+      const testInfoObject = {
+        id: 'testId',
+        title: 'test name',
+        status: 'skipped',
+        parentId: 'suiteId',
+      };
+
+      reporter.pendingTestsIds = [testInfoObject.id];
+
+      reporter.testStart(testInfoObject);
+
+      expect(spyStartTestItem).toHaveBeenCalledTimes(1);
+      expect(spyTestEnd).toHaveBeenCalledTimes(1);
+      expect(spyTestEnd).toHaveBeenCalledWith(testInfoObject);
+    });
+  });
+
   describe('sendLogOnFinishItem: without attachments', () => {
     beforeAll(() => {
       mockFS();


### PR DESCRIPTION
Fixed skipped tests by listening to `EVENT_TEST_PENDING`. Skipped tests are now handled in `reporter.testStart()` and `reporter.testPending()` to make it work independent from order of events coming in. 