### PR TITLE
Fix passing mode property from config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ const updatedConfig = {
 
 ```
 
+For security reasons, you can also set token as a part of Environment Variables, instead of sharing it in the config file:
+
 **Overwrite by env variables:**
 
 | Parameter | Env variable |

--- a/README.md
+++ b/README.md
@@ -156,9 +156,7 @@ const updatedConfig = {
 
 ```
 
-For security reasons, you can also set token as a part of Environment Variables, instead of sharing it in the config file:
-
-**Overwrite by env variables:**
+**For security reasons, you can also set token as a part of Environment Variables, instead of sharing it in the config file:**
 
 | Parameter | Env variable |
 |-----------|--------------|

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -132,6 +132,7 @@ const getLaunchStartObject = (config) => {
     attributes: launchAttributes,
     rerun: config.reporterOptions.rerun,
     rerunOf: config.reporterOptions.rerunOf,
+    mode: config.reporterOptions.mode,
     startTime: new Date().valueOf(),
   };
 };

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -320,6 +320,7 @@ describe('utils script', () => {
         };
 
         const startLaunchObject = getLaunchStartObject(getDefaultConfig());
+
         expect(startLaunchObject).toBeDefined();
         expect(startLaunchObject).toEqual(expectedStartLaunchObject);
       });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -316,10 +316,10 @@ describe('utils script', () => {
           startTime: currentDate,
           rerun: undefined,
           rerunOf: undefined,
+          mode: undefined,
         };
 
         const startLaunchObject = getLaunchStartObject(getDefaultConfig());
-
         expect(startLaunchObject).toBeDefined();
         expect(startLaunchObject).toEqual(expectedStartLaunchObject);
       });


### PR DESCRIPTION
Add `mode` property to `utils.getLaunchStartObject()`. `mode` is a documented config option, but not working in current version of `agent-js-cypress`.