### PR TITLE
fix: reporter unhandled rejected promise

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -240,7 +240,7 @@ class Reporter {
   }
 
   sendLog(tempId, { level, message = '', file }) {
-    this.client.sendLog(
+    return this.client.sendLog(
       tempId,
       {
         message,
@@ -254,11 +254,15 @@ class Reporter {
   sendLogToCurrentItem(log) {
     const tempItemId =
       (this.currentTestTempInfo && this.currentTestTempInfo.tempId) || this.getCurrentSuiteId();
-    tempItemId && this.sendLog(tempItemId, log);
+    if (tempItemId) {
+      const { promise } = this.sendLog(tempItemId, log);
+      promiseErrorHandler(promise, 'Fail to send log to current item');
+    }
   }
 
   sendLaunchLog(log) {
-    this.sendLog(this.tempLaunchId, log);
+    const { promise } = this.sendLog(this.tempLaunchId, log);
+    promiseErrorHandler(promise, 'Fail to send launch log');
   }
 
   addAttributes(attributes) {

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -248,20 +248,20 @@ class Reporter {
         time: new Date().valueOf(),
       },
       file,
-    );
+    ).promise;
   }
 
   sendLogToCurrentItem(log) {
     const tempItemId =
       (this.currentTestTempInfo && this.currentTestTempInfo.tempId) || this.getCurrentSuiteId();
     if (tempItemId) {
-      const { promise } = this.sendLog(tempItemId, log);
+      const promise = this.sendLog(tempItemId, log);
       promiseErrorHandler(promise, 'Fail to send log to current item');
     }
   }
 
   sendLaunchLog(log) {
-    const { promise } = this.sendLog(this.tempLaunchId, log);
+    const promise = this.sendLog(this.tempLaunchId, log);
     promiseErrorHandler(promise, 'Fail to send launch log');
   }
 

--- a/test/reporter.test.js
+++ b/test/reporter.test.js
@@ -600,6 +600,9 @@ describe('reporter script', () => {
     });
   });
   describe('send log', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
     it('sendLog: client.sendLog should be called with parameters', function() {
       const spySendLog = jest.spyOn(reporter.client, 'sendLog');
       const logObj = {
@@ -633,6 +636,18 @@ describe('reporter script', () => {
 
       expect(spySendLog).toHaveBeenCalledWith('tempTestItemId', expectedLogObj, undefined);
     });
+    it('sendLogToCurrentItem: client.sendLog rejected promise should be handled', async function() {
+      const spyConsoleError = jest.spyOn(global.console, 'error').mockImplementation();
+      const clientError = new Error('client call failed');
+      jest
+        .spyOn(reporter.client, 'sendLog')
+        .mockReturnValue({ promise: Promise.reject(clientError) });
+      await reporter.sendLogToCurrentItem({
+        level: 'error',
+        message: 'error message',
+      });
+      expect(spyConsoleError).toHaveBeenCalledWith('Fail to send log to current item', clientError);
+    });
     it('sendLaunchLog: client.sendLog should be called with parameters', function() {
       const spySendLog = jest.spyOn(reporter.client, 'sendLog');
       const logObj = {
@@ -649,6 +664,18 @@ describe('reporter script', () => {
       reporter.sendLaunchLog(logObj);
 
       expect(spySendLog).toHaveBeenCalledWith('tempLaunchId', expectedLogObj, undefined);
+    });
+    it('sendLaunchLog: client.sendLog rejected promise should be handled', async function() {
+      const spyConsoleError = jest.spyOn(global.console, 'error').mockImplementation();
+      const clientError = new Error('client call failed');
+      jest
+        .spyOn(reporter.client, 'sendLog')
+        .mockReturnValue({ promise: Promise.reject(clientError) });
+      await reporter.sendLaunchLog({
+        level: 'error',
+        message: 'error message',
+      });
+      expect(spyConsoleError).toHaveBeenCalledWith('Fail to send launch log', clientError);
     });
   });
   describe('addAttributes', () => {


### PR DESCRIPTION
Hello, 

This is a small fix that would really help in my current project to prevent agent from crashing my test execution when endpoint is not available. 

It can very easily be reproduced by changing endpoint url to an invalid one in `cypress.config.js` file `reporterOptions.endpoint` (e.g replace to `api/v3`, which shouldn't exist).

I've added tests to cover my changes.