### PR TITLE
Remove lock files on uncaught exceptions

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -84,10 +84,7 @@ class Reporter {
         ),
       )
       .promise.then(() => {
-        const { launch, isLaunchMergeRequired } = this.config.reporterOptions;
-        if (isLaunchMergeRequired) {
-          deleteMergeLaunchLockFile(launch, this.tempLaunchId);
-        }
+        this.finish();
       })
       .then(() => {
         const { parallel, autoMerge } = this.config.reporterOptions;
@@ -96,6 +93,9 @@ class Reporter {
         }
 
         return mergeParallelLaunches(this.client, this.config);
+      })
+      .catch((error) => {
+        this.finish(error);
       });
     return promiseErrorHandler(finishLaunchPromise, 'Fail to finish launch');
   }
@@ -240,7 +240,7 @@ class Reporter {
   }
 
   sendLog(tempId, { level, message = '', file }) {
-    this.client.sendLog(
+    const promise = this.client.sendLog(
       tempId,
       {
         message,
@@ -248,7 +248,8 @@ class Reporter {
         time: new Date().valueOf(),
       },
       file,
-    );
+    ).promise;
+    promiseErrorHandler(promise, 'Fail to send log');
   }
 
   sendLogToCurrentItem(log) {
@@ -293,6 +294,23 @@ class Reporter {
 
   saveCustomScreenshotFilename({ fileName }) {
     this.currentTestCustomScreenshots.push(fileName);
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  exceptionHandler(error, origin) {
+    this.finish(error);
+  }
+
+  finish(error) {
+    const { launch, isLaunchMergeRequired } = this.config.reporterOptions;
+    if (isLaunchMergeRequired) {
+      if (error) {
+        console.log(
+          `Delete merge launch lock file for launch ${launch} with id ${this.tempLaunchId}.`,
+        );
+      }
+      deleteMergeLaunchLockFile(launch, this.tempLaunchId);
+    }
   }
 }
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -99,3 +99,14 @@ process.on('message', (message) => {
       break;
   }
 });
+
+process.on('uncaughtException', async (err, origin) => {
+  reporter.exceptionHandler(err, origin);
+  process.exit(1);
+});
+
+// eslint-disable-next-line no-unused-vars
+process.on('unhandledRejection', async (reason, promise) => {
+  reporter.exceptionHandler(reason);
+  process.exit(1);
+});


### PR DESCRIPTION
For the workaround in #135 to work reliable, we must make sure the lock files are always removed. Especially on errors, this is currently not the case. There might be more changes needed, but the proposed changes at least catch the main problems I found when working with it.