### PR TITLE
Do not detach worker

### DIFF
--- a/lib/cypressReporter.js
+++ b/lib/cypressReporter.js
@@ -56,9 +56,7 @@ class CypressReporter extends Mocha.reporters.Base {
       !config.reporterOptions.autoMerge ||
       CypressReporter.reporterOptions.parallel
     ) {
-      this.worker = fork(`${__dirname}/worker.js`, [], {
-        detached: true,
-      });
+      this.worker = fork(`${__dirname}/worker.js`, []);
       this.worker.send({ event: reporterEvents.INIT, config });
 
       const configListener = (cypressFullConfig) => {


### PR DESCRIPTION
I found detaching the worker to leave my system with lot's of zombie processes, for example if test crashes. Any reason why detaching the worker is really required?