### PR TITLE
Allow setting description and attributes for suites

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -112,6 +112,8 @@ class Reporter {
     const suiteId = this.testItemIds.get(suite.id);
     const suiteTestCaseId = this.suiteTestCaseIds.get(suite.title);
     const suiteStatus = this.suiteStatuses.get(suite.title);
+    const suiteInfo = this.getCurrentSuiteInfo();
+
     const finishTestItemPromise = this.client.finishTestItem(
       suiteId,
       Object.assign(
@@ -120,6 +122,8 @@ class Reporter {
         },
         suiteTestCaseId && { testCaseId: suiteTestCaseId },
         suiteStatus && { status: suiteStatus },
+        suiteInfo && suiteInfo.description && { description: suiteInfo.description },
+        suiteInfo && suiteInfo.attributes && { attributes: suiteInfo.attributes },
       ),
     ).promise;
     promiseErrorHandler(finishTestItemPromise, 'Fail to finish suite');
@@ -262,13 +266,21 @@ class Reporter {
   }
 
   addAttributes(attributes) {
-    this.currentTestFinishParams.attributes = this.currentTestFinishParams.attributes.concat(
-      attributes || [],
-    );
+    if (this.currentTestTempInfo == null && this.getCurrentSuiteInfo() != null) {
+      this.getCurrentSuiteInfo().attributes = attributes;
+    } else {
+      this.currentTestFinishParams.attributes = this.currentTestFinishParams.attributes.concat(
+        attributes || [],
+      );
+    }
   }
 
   setDescription(description) {
-    this.currentTestFinishParams.description = description;
+    if (this.currentTestTempInfo == null && this.getCurrentSuiteInfo() != null) {
+      this.getCurrentSuiteInfo().description = description;
+    } else {
+      this.currentTestFinishParams.description = description;
+    }
   }
 
   setTestCaseId({ testCaseId, suiteTitle }) {

--- a/test/reporter.test.js
+++ b/test/reporter.test.js
@@ -134,6 +134,36 @@ describe('reporter script', () => {
       expect(spyFinishTestItem).toHaveBeenCalledTimes(1);
       expect(spyFinishTestItem).toHaveBeenCalledWith('tempSuiteId', { endTime: currentDate });
     });
+
+    it('finishTestItem should have description and attributes from suite stack top item', function() {
+      const spyFinishTestItem = jest.spyOn(reporter.client, 'finishTestItem');
+
+      const attributes = [{ key: 'test key', value: 'test value' }];
+      const description = 'test description';
+
+      reporter.testItemIds.set('suiteId', 'tempSuiteId');
+      reporter.suitesStackTempInfo.push({
+        tempId: 'tempSuiteId',
+        title: 'suite title',
+      });
+
+      const suiteEndObject = {
+        id: 'suiteId',
+        endTime: currentDate,
+      };
+
+      reporter.addAttributes(attributes);
+      reporter.setDescription(description);
+      reporter.suiteEnd(suiteEndObject);
+
+      expect(spyFinishTestItem).toHaveBeenCalledTimes(1);
+      expect(spyFinishTestItem).toHaveBeenCalledWith('tempSuiteId', {
+        description,
+        endTime: currentDate,
+        attributes,
+      });
+    });
+
     it('end suite with testCaseId: finishTestItem should be called with testCaseId', function() {
       const spyFinishTestItem = jest.spyOn(reporter.client, 'finishTestItem');
       reporter.testItemIds.set('suiteId', 'tempSuiteId');


### PR DESCRIPTION
Allow setting description and attributes for suites in the `before()` hook of a suite. This will enable users to improve test suite representation in Report Portal.

```typescript
describe("suite", function () {
  before(() => {
    cy.setTestDescription("This suite does ...");
    cy.addTestAttributes([{ key: "attibute", value: "value" }]);
  });

  context("a sub suite", () => {
    before(() => {
      cy.setTestDescription("This is a suite inside a suite...");
      cy.addTestAttributes([{ key: "attibute", value: "value" }]);
    });

    it("test case", function () {
      cy.setTestDescription("This is a test case...");
      cy.addTestAttributes([{ key: "attibute", value: "value" }]);
    });
  });
});
```