### PR TITLE
Allow disabling plugin

### DIFF
--- a/lib/plugin/index.js
+++ b/lib/plugin/index.js
@@ -57,4 +57,33 @@ const registerReportPortalPlugin = (on, config) => {
   });
 };
 
-module.exports = registerReportPortalPlugin;
+const disableReportPortalPlugin = (on) => {
+  on('task', {
+    rp_Log() {
+      return null;
+    },
+    rp_launchLog() {
+      return null;
+    },
+    rp_addTestAttributes() {
+      return null;
+    },
+    rp_setTestDescription() {
+      return null;
+    },
+    rp_setTestCaseId() {
+      return null;
+    },
+    rp_screenshot() {
+      return null;
+    },
+    rp_setStatus() {
+      return null;
+    },
+    rp_setLaunchStatus() {
+      return null;
+    },
+  });
+};
+
+module.exports = { registerReportPortalPlugin, disableReportPortalPlugin };


### PR DESCRIPTION
When using custom commands, it is not enough to just remove `registerReportPortalPlugin(on, config)` from Cypress configuration as tasks will not be registered. We also use different cypress configs, for example one for local development and one for ci integration. There has to be a way to configure the tasks without the tests to break.

Introduced `disableReportPortalPlugin(on)` that simply creates no-op tasks for all custom commands.