### PR TITLE
Upload videos 

### DIFF
--- a/lib/plugin/index.js
+++ b/lib/plugin/index.js
@@ -17,9 +17,10 @@
 const ipc = require('node-ipc');
 const { connectIPCClient } = require('./ipcClient');
 const { IPC_EVENTS } = require('./../ipcEvents');
+const { prepareReporterOptions } = require('./../utils');
 
 const registerReportPortalPlugin = (on, config) => {
-  connectIPCClient(config);
+  connectIPCClient(prepareReporterOptions(config));
 
   on('task', {
     rp_Log(log) {

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -24,6 +24,7 @@ const {
   getTestEndObject,
   getHookStartObject,
   getAgentInfo,
+  getVideoFile,
 } = require('./utils');
 
 const { createMergeLaunchLockFile, deleteMergeLaunchLockFile } = require('./mergeLaunchesUtils');
@@ -105,13 +106,26 @@ class Reporter {
     const { tempId, promise } = this.client.startTestItem(suite, this.tempLaunchId, parentId);
     promiseErrorHandler(promise, 'Fail to start suite');
     this.testItemIds.set(suite.id, tempId);
-    this.suitesStackTempInfo.push({ tempId, startTime: suite.startTime });
+    this.suitesStackTempInfo.push({
+      tempId,
+      startTime: suite.startTime,
+      title: suite.name || '',
+      id: suite.id,
+      testFileName: suite.testFileName,
+    });
   }
 
   suiteEnd(suite) {
     const suiteId = this.testItemIds.get(suite.id);
     const suiteTestCaseId = this.suiteTestCaseIds.get(suite.title);
     const suiteStatus = this.suiteStatuses.get(suite.title);
+
+    // if suite fails, also the root suite status must fail
+    if (suite.status === testItemStatuses.FAILED) {
+      this.suitesStackTempInfo[0].status = suite.status;
+    }
+    this.sendVideoOnFinishSuite(suite);
+
     const finishTestItemPromise = this.client.finishTestItem(
       suiteId,
       Object.assign(
@@ -139,6 +153,37 @@ class Reporter {
     promiseErrorHandler(promise, 'Fail to start test');
     this.testItemIds.set(test.id, tempId);
     this.currentTestTempInfo = { tempId, startTime: startTestObj.startTime };
+  }
+
+  sendVideoOnFinishSuite(suite) {
+    if (!this.suitesStackTempInfo.length || suite.id !== this.suitesStackTempInfo[0].id) {
+      return;
+    }
+    // do not upload video if root suite passes and videoUploadOnPasses is false
+    const videoUploadOnPasses = this.config.reporterOptions.videoUploadOnPasses || false;
+    if (this.suitesStackTempInfo[0].status !== testItemStatuses.FAILED && !videoUploadOnPasses) {
+      return;
+    }
+
+    const testFileName = this.suitesStackTempInfo[0].testFileName;
+    if (!testFileName) return;
+
+    const videosFolder = this.config.reporterOptions.videosFolder;
+    const specFileName = testFileName.split('/').pop();
+    const videoFileDetails = getVideoFile(specFileName, videosFolder);
+    if (!videoFileDetails) return;
+
+    const suiteId = this.testItemIds.get(suite.id);
+    const sendVideoPromise = this.client.sendLog(
+      suiteId,
+      {
+        message: `Video: '${suite.title}' (${specFileName}.mp4)`,
+        level: logLevels.INFO,
+        time: new Date().valueOf(),
+      },
+      videoFileDetails,
+    ).promise;
+    promiseErrorHandler(sendVideoPromise, 'Fail to save video');
   }
 
   sendLogOnFinishItem(test, tempTestId) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -72,6 +72,21 @@ const getFailedScreenshot = (testTitle) => {
     : undefined;
 };
 
+const getVideoFile = (specFileName, videosFolder = '**') => {
+  if (specFileName == null) return specFileName;
+  const fileName = specFileName.toLowerCase().endsWith('.mp4')
+    ? specFileName
+    : `${specFileName}.mp4`;
+  const videoFile = glob.sync(`${videosFolder}/${fileName}`);
+  if (!videoFile.length) return undefined;
+
+  return {
+    name: fileName,
+    type: 'video/mp4',
+    content: base64Encode(videoFile[0]),
+  };
+};
+
 const getCodeRef = (testItemPath, testFileName) =>
   `${testFileName.replace(/\\/g, '/')}/${testItemPath.join('/')}`;
 
@@ -121,6 +136,23 @@ const getConfig = (initialConfig) => {
   };
 };
 
+const prepareReporterOptions = (config) => {
+  // copy this options from cypess config to report portal options
+  const passthroughOptions = {
+    videosFolder: config.videosFolder,
+    screenshotsFolder: config.screenshotsFolder,
+    videoUploadOnPasses: config.videoUploadOnPasses,
+  };
+
+  return {
+    ...config,
+    reporterOptions: {
+      ...passthroughOptions,
+      ...config.reporterOptions,
+    },
+  };
+};
+
 const getLaunchStartObject = (config) => {
   const launchAttributes = (config.reporterOptions.attributes || []).concat(
     getSystemAttributes(config),
@@ -145,13 +177,22 @@ const getSuiteStartObject = (suite, testFileName) => ({
   attributes: [],
   codeRef: getCodeRef(suite.titlePath(), testFileName),
   parentId: !suite.root ? suite.parent.id : undefined,
+  testFileName,
 });
 
-const getSuiteEndObject = (suite) => ({
-  id: suite.id,
-  title: suite.title,
-  endTime: new Date().valueOf(),
-});
+const getSuiteEndObject = (suite) => {
+  let failed = false;
+  if (suite.tests != null) {
+    const states = suite.tests.map((test) => test.state);
+    failed = states.includes(testItemStatuses.FAILED);
+  }
+  return {
+    id: suite.id,
+    status: failed ? testItemStatuses.FAILED : undefined,
+    title: suite.title,
+    endTime: new Date().valueOf(),
+  };
+};
 
 const getTestInfo = (test, testFileName, status, err) => ({
   id: test.id,
@@ -291,7 +332,9 @@ module.exports = {
   getHookStartObject,
   getTotalSpecs,
   getConfig,
+  prepareReporterOptions,
   getExcludeSpecPattern,
   getFixtureFolderPattern,
   getSpecPattern,
+  getVideoFile,
 };

--- a/test/reporter.test.js
+++ b/test/reporter.test.js
@@ -176,6 +176,136 @@ describe('reporter script', () => {
     });
   });
 
+  describe('sendVideoOnFinishSuite', function() {
+    let customSuiteNameAttachment;
+
+    beforeAll(() => {
+      mockFS({
+        'example/screenshots/example.spec.js': {
+          videos: {
+            'custom suite name.cy.ts.mp4': Buffer.from([1, 2, 7, 9, 3, 0, 5]),
+          },
+        },
+      });
+    });
+
+    afterAll(() => {
+      mockFS.restore();
+    });
+
+    this.beforeEach(() => {
+      customSuiteNameAttachment = {
+        name: `custom suite name.cy.ts.mp4`,
+        type: 'video/mp4',
+        content: Buffer.from([1, 2, 7, 9, 3, 0, 5]).toString('base64'),
+      };
+      reporter.suitesStackTempInfo = [
+        { id: 'root', testFileName: 'custom suite name.cy.ts' },
+        { id: 'suite' },
+      ];
+      reporter.testItemIds.set('root', 'suiteTempId');
+    });
+
+    afterEach(() => {
+      reporter.suitesStackTempInfo = [];
+      delete reporter.config.reporterOptions.videoUploadOnPasses;
+    });
+
+    it('sendLog with video attachment - fail root suite if sub suite fails', function() {
+      const suiteEndObject = {
+        id: 'suite',
+        title: 'suite title',
+        status: 'failed',
+      };
+
+      expect(reporter.suitesStackTempInfo[0].status).not.toBeDefined();
+      reporter.suiteEnd(suiteEndObject);
+      expect(reporter.suitesStackTempInfo[0].status).toEqual('failed');
+    });
+
+    it('sendLog with video attachment - send log with video for failed root suite', function() {
+      const spySendVideoOnFinishSuite = jest.spyOn(reporter.client, 'sendLog');
+
+      reporter.setTestItemStatus({ status: 'failed', suiteTitle: 'suite title' });
+
+      const suiteEndObject = {
+        id: 'root',
+        title: 'suite title',
+        status: 'failed',
+      };
+
+      reporter.suiteEnd(suiteEndObject);
+
+      expect(spySendVideoOnFinishSuite).toHaveBeenCalledTimes(1);
+      expect(spySendVideoOnFinishSuite).toHaveBeenCalledWith(
+        'suiteTempId',
+        {
+          message: `Video: '${suiteEndObject.title}' (custom suite name.cy.ts.mp4)`,
+          level: 'info',
+          time: new Date().valueOf(),
+        },
+        customSuiteNameAttachment,
+      );
+    });
+
+    it('sendLog with video attachment - do not send if suite is not root suite', function() {
+      const spySendVideoOnFinishSuite = jest.spyOn(reporter.client, 'sendLog');
+
+      reporter.setTestItemStatus({ status: 'passed', suiteTitle: 'suite title' });
+
+      const suiteEndObject = {
+        id: 'suite',
+        title: 'suite title',
+        status: 'passed',
+      };
+
+      reporter.suiteEnd(suiteEndObject);
+
+      expect(spySendVideoOnFinishSuite).not.toHaveBeenCalled();
+    });
+
+    it('sendLog with video attachment - do not send if root suite passed and videoUploadOnPasses is false', function() {
+      const spySendVideoOnFinishSuite = jest.spyOn(reporter.client, 'sendLog');
+
+      reporter.setTestItemStatus({ status: 'passed', suiteTitle: 'suite title' });
+
+      const suiteEndObject = {
+        id: 'root',
+        title: 'suite title',
+        status: 'passed',
+      };
+
+      reporter.suiteEnd(suiteEndObject);
+
+      expect(spySendVideoOnFinishSuite).not.toHaveBeenCalled();
+    });
+
+    it('sendLog with video attachment - send if root suite passed and videoUploadOnPasses is true', function() {
+      const spySendVideoOnFinishSuite = jest.spyOn(reporter.client, 'sendLog');
+      reporter.config.reporterOptions.videoUploadOnPasses = true;
+      reporter.setTestItemStatus({ status: 'passed', suiteTitle: 'suite title' });
+
+      const suiteEndObject = {
+        id: 'root',
+        title: 'suite title',
+        status: 'passed',
+      };
+
+      reporter.suiteEnd(suiteEndObject);
+
+      expect(spySendVideoOnFinishSuite).toHaveBeenCalledTimes(1);
+      expect(spySendVideoOnFinishSuite).toHaveBeenCalledWith(
+        'suiteTempId',
+        {
+          message: `Video: '${suiteEndObject.title}' (custom suite name.cy.ts.mp4)`,
+          level: 'info',
+          time: new Date().valueOf(),
+        },
+        customSuiteNameAttachment,
+      );
+    });
+  });
+
   describe('testStart', function() {
     it('startTestItem should be called with parameters', function() {
       const spyStartTestItem = jest.spyOn(reporter.client, 'startTestItem');

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -20,6 +20,8 @@ const {
   getFixtureFolderPattern,
   getExcludeSpecPattern,
   getSpecPattern,
+  getVideoFile,
+  prepareReporterOptions,
 } = require('./../lib/utils');
 const pjson = require('./../package.json');
 
@@ -36,6 +38,9 @@ describe('utils script', () => {
           'customScreenshot1.png': Buffer.from([1, 1, 1, 1, 1, 1, 1]),
           customDir: {
             'customScreenshot2.png': Buffer.from([2, 2, 2, 2, 2, 2, 2]),
+          },
+          videos: {
+            'custom suite name.cy.ts.mp4': Buffer.from([1, 2, 7, 9, 3, 0, 5]),
           },
         },
       });
@@ -120,6 +125,34 @@ describe('utils script', () => {
       expect(attachments).toBeDefined();
       expect(attachments.length).toEqual(0);
       jest.clearAllMocks();
+    });
+
+    it('getVideoFile: should return video file attachment with videosFolder', () => {
+      const testFileName = 'custom suite name.cy.ts';
+      const expectedAttachment = {
+        name: `${testFileName}.mp4`,
+        type: 'video/mp4',
+        content: Buffer.from([1, 2, 7, 9, 3, 0, 5]).toString('base64'),
+      };
+
+      const attachment = getVideoFile(testFileName, 'example/screenshots/example.spec.js/videos');
+
+      expect(attachment).toBeDefined();
+      expect(attachment).toEqual(expectedAttachment);
+    });
+
+    it('getVideoFile: should return video file attachment without videosFolder', () => {
+      const testFileName = 'custom suite name.cy.ts';
+      const expectedAttachment = {
+        name: `${testFileName}.mp4`,
+        type: 'video/mp4',
+        content: Buffer.from([1, 2, 7, 9, 3, 0, 5]).toString('base64'),
+      };
+
+      const attachment = getVideoFile(testFileName);
+
+      expect(attachment).toBeDefined();
+      expect(attachment).toEqual(expectedAttachment);
     });
   });
 
@@ -301,6 +334,28 @@ describe('utils script', () => {
       });
     });
 
+    describe('prepareReporterOptions', function() {
+      it('should pass video related cypress options from cypress config', function() {
+        const initialConfig = getDefaultConfig();
+        initialConfig.videosFolder = '/example/videos';
+        initialConfig.videoUploadOnPasses = true;
+
+        const config = prepareReporterOptions(initialConfig);
+
+        expect(config.reporterOptions.videosFolder).toEqual('/example/videos');
+        expect(config.reporterOptions.videoUploadOnPasses).toEqual(true);
+      });
+
+      it('passing video related cypress options should not fail if undefined', function() {
+        const initialConfig = getDefaultConfig();
+
+        const config = prepareReporterOptions(initialConfig);
+
+        expect(config.reporterOptions.videosFolder).not.toBeDefined();
+        expect(config.reporterOptions.videoUploadOnPasses).not.toBeDefined();
+      });
+    });
+
     describe('getLaunchStartObject', () => {
       test('should return start launch object with correct values', () => {
         const expectedStartLaunchObject = {
@@ -343,6 +398,7 @@ describe('utils script', () => {
           attributes: [],
           codeRef: 'test/example.spec.js/suite name',
           parentId: undefined,
+          testFileName: 'test\\example.spec.js',
         };
 
         const suiteStartObject = getSuiteStartObject(suite, testFileName);
@@ -370,6 +426,7 @@ describe('utils script', () => {
           attributes: [],
           codeRef: 'test/example.spec.js/parent suite name/suite name',
           parentId: 'parentSuiteId',
+          testFileName: 'test\\example.spec.js',
         };
 
         const suiteStartObject = getSuiteStartObject(suite, testFileName);


### PR DESCRIPTION
Another approach at uploading videos to the launch log in `suiteEnd()`. To support Cypress `videosFolder` and `videoUploadOnPasses` config options, this options need to be passed to `reporterOptions` when the plugin is initialized. Not sure if there is another or better way, but seems to be working very well. Added tests to document the behavior. 

Please note, for `videoUploadOnPasses` to work, the status of the root suite in `suitesStackTempInfo` needs to be updated to `failed` if any of it's sub suites fails.

