### PR TITLE
Allow passing time to reporter.sendLog()

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -239,13 +239,13 @@ class Reporter {
     return currentSuiteInfo && currentSuiteInfo.tempId;
   }
 
-  sendLog(tempId, { level, message = '', file }) {
+  sendLog(tempId, { level, message = '', file, time }) {
     this.client.sendLog(
       tempId,
       {
         message,
         level,
-        time: new Date().valueOf(),
+        time: time || new Date().valueOf(),
       },
       file,
     );

--- a/test/reporter.test.js
+++ b/test/reporter.test.js
@@ -616,6 +616,23 @@ describe('reporter script', () => {
 
       expect(spySendLog).toHaveBeenCalledWith('tempTestItemId', expectedLogObj, undefined);
     });
+    it('sendLog: client.sendLog should be called with time passed in log object', function() {
+      const spySendLog = jest.spyOn(reporter.client, 'sendLog');
+      const logObj = {
+        level: 'error',
+        message: 'error message',
+        time: 1674158678,
+      };
+      const expectedLogObj = {
+        level: 'error',
+        message: 'error message',
+        time: 1674158678,
+      };
+
+      reporter.sendLog('tempTestItemId', logObj);
+
+      expect(spySendLog).toHaveBeenCalledWith('tempTestItemId', expectedLogObj, undefined);
+    });
     it('sendLogToCurrentItem: client.sendLog should be called with parameters', function() {
       const spySendLog = jest.spyOn(reporter.client, 'sendLog');
       const logObj = {
@@ -643,6 +660,24 @@ describe('reporter script', () => {
         level: 'error',
         message: 'error message',
         time: currentDate,
+      };
+      reporter.tempLaunchId = 'tempLaunchId';
+
+      reporter.sendLaunchLog(logObj);
+
+      expect(spySendLog).toHaveBeenCalledWith('tempLaunchId', expectedLogObj, undefined);
+    });
+    it('sendLaunchLog: client.sendLog should be called with time passed in log object', function() {
+      const spySendLog = jest.spyOn(reporter.client, 'sendLog');
+      const logObj = {
+        level: 'error',
+        message: 'error message',
+        time: 1674158678,
+      };
+      const expectedLogObj = {
+        level: 'error',
+        message: 'error message',
+        time: 1674158678,
       };
       reporter.tempLaunchId = 'tempLaunchId';
 


### PR DESCRIPTION
Enable users to pass time to `reporter.sendLog`. By passing log timestamp from the tests, it is for example possible to preserve order of logs. It is also important if there is some sort of caching implemented in the test framework.

```typescript
cy.task("rp_Log", {
  level: "info",
  message,
  time: logTimestamp,
});
```

