### PR TITLE
Add attributes from cypres-grep tags

### DIFF
--- a/lib/cypressReporter.js
+++ b/lib/cypressReporter.js
@@ -123,7 +123,7 @@ class CypressReporter extends Mocha.reporters.Base {
       if (!suite.title) return;
       this.worker.send({
         event: EVENT_SUITE_BEGIN,
-        suite: getSuiteStartObject(suite, this.runner.suite.file),
+        suite: getSuiteStartObject(suite, this.runner.suite.file, this.config.reporterOptions),
       });
     });
 

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -130,7 +130,7 @@ class Reporter {
 
   testStart(test) {
     const parentId = this.testItemIds.get(test.parentId);
-    const startTestObj = getTestStartObject(test);
+    const startTestObj = getTestStartObject(test, this.config.reporterOptions);
     const { tempId, promise } = this.client.startTestItem(
       startTestObj,
       this.tempLaunchId,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-underscore-dangle */
 /*
  *  Copyright 2022 EPAM Systems
  *
@@ -136,16 +137,31 @@ const getLaunchStartObject = (config) => {
   };
 };
 
-const getSuiteStartObject = (suite, testFileName) => ({
-  id: suite.id,
-  type: entityType.SUITE,
-  name: suite.title.slice(0, 255).toString(),
-  startTime: new Date().valueOf(),
-  description: suite.description,
-  attributes: [],
-  codeRef: getCodeRef(suite.titlePath(), testFileName),
-  parentId: !suite.root ? suite.parent.id : undefined,
-});
+const attributesForTags = (tags) => {
+  if (!tags) return tags;
+  if (typeof tags === 'string') {
+    return tags.split(' ').map((tag) => ({ value: tag }));
+  }
+  if (Array.isArray(tags)) {
+    return tags.map((tag) => ({ value: tag }));
+  }
+  return undefined;
+};
+
+const getSuiteStartObject = (suite, testFileName) => {
+  // eslint-disable-next-line no-underscore-dangle
+  const tags = suite._testConfig && suite._testConfig.tags;
+  return {
+    id: suite.id,
+    type: entityType.SUITE,
+    name: suite.title.slice(0, 255).toString(),
+    startTime: new Date().valueOf(),
+    description: suite.description,
+    attributes: attributesForTags(tags) || [],
+    codeRef: getCodeRef(suite.titlePath(), testFileName),
+    parentId: !suite.root ? suite.parent.id : undefined,
+  };
+};
 
 const getSuiteEndObject = (suite) => ({
   id: suite.id,
@@ -153,22 +169,36 @@ const getSuiteEndObject = (suite) => ({
   endTime: new Date().valueOf(),
 });
 
-const getTestInfo = (test, testFileName, status, err) => ({
-  id: test.id,
-  status: status || (test.state === 'pending' ? testItemStatuses.SKIPPED : test.state),
-  title: test.title,
-  codeRef: getCodeRef(test.titlePath(), testFileName),
-  parentId: test.parent.id,
-  err: (err && err.message) || err || (test.err && test.err.message),
-  testFileName,
-});
+const getTestInfo = (test, testFileName, status, err) => {
+  // read cypress-grep tags from runnable.
+  // if tags of test are inherited from it's parent ignore them
+  let testTags;
+  if (test._testConfig && test._testConfig.unverifiedTestConfig) {
+    testTags = test._testConfig.unverifiedTestConfig.tags;
+  }
+  const parentTags = test.parent._testConfig && test.parent._testConfig.tags;
+  if (testTags && parentTags === testTags) {
+    testTags = undefined;
+  }
+
+  return {
+    id: test.id,
+    status: status || (test.state === 'pending' ? testItemStatuses.SKIPPED : test.state),
+    title: test.title,
+    codeRef: getCodeRef(test.titlePath(), testFileName),
+    parentId: test.parent.id,
+    err: (err && err.message) || err || (test.err && test.err.message),
+    testFileName,
+    tags: testTags,
+  };
+};
 
 const getTestStartObject = (test) => ({
   type: entityType.STEP,
   name: test.title.slice(0, 255).toString(),
   startTime: new Date().valueOf(),
   codeRef: test.codeRef,
-  attributes: [],
+  attributes: attributesForTags(test.tags) || [],
 });
 
 const getTestEndObject = (testInfo, skippedIssue) => {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -137,8 +137,12 @@ const getLaunchStartObject = (config) => {
   };
 };
 
-const attributesForTags = (tags) => {
+const attributesForTags = (tags, options) => {
   if (!tags) return tags;
+  if (options) {
+    const addAttributes = options.addCypressGrepAttributes;
+    if (addAttributes === false) return undefined;
+  }
   if (typeof tags === 'string') {
     return tags.split(' ').map((tag) => ({ value: tag }));
   }
@@ -148,7 +152,7 @@ const attributesForTags = (tags) => {
   return undefined;
 };
 
-const getSuiteStartObject = (suite, testFileName) => {
+const getSuiteStartObject = (suite, testFileName, reporterOptions) => {
   // eslint-disable-next-line no-underscore-dangle
   const tags = suite._testConfig && suite._testConfig.tags;
   return {
@@ -157,7 +161,7 @@ const getSuiteStartObject = (suite, testFileName) => {
     name: suite.title.slice(0, 255).toString(),
     startTime: new Date().valueOf(),
     description: suite.description,
-    attributes: attributesForTags(tags) || [],
+    attributes: attributesForTags(tags, reporterOptions) || [],
     codeRef: getCodeRef(suite.titlePath(), testFileName),
     parentId: !suite.root ? suite.parent.id : undefined,
   };
@@ -193,12 +197,12 @@ const getTestInfo = (test, testFileName, status, err) => {
   };
 };
 
-const getTestStartObject = (test) => ({
+const getTestStartObject = (test, reporterOptions) => ({
   type: entityType.STEP,
   name: test.title.slice(0, 255).toString(),
   startTime: new Date().valueOf(),
   codeRef: test.codeRef,
-  attributes: attributesForTags(test.tags) || [],
+  attributes: attributesForTags(test.tags, reporterOptions) || [],
 });
 
 const getTestEndObject = (testInfo, skippedIssue) => {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -408,10 +408,17 @@ describe('utils script', () => {
         // test attributes from array of tags reusing previous check
         // eslint-disable-next-line no-underscore-dangle
         suite._testConfig.tags = ['tag1', 'tag2', 'tag3'];
-        const suiteStartObject2 = getSuiteStartObject(suite, testFileName);
+        const suiteStartObject2 = getSuiteStartObject(suite, testFileName, {});
 
         expect(suiteStartObject2).toBeDefined();
         expect(suiteStartObject2).toEqual(expectedSuiteStartObject);
+
+        // test disabling cypress grep attributes in reporterOptions
+        const options = { addCypressGrepAttributes: false };
+        const suiteStartObject3 = getSuiteStartObject(suite, testFileName, options);
+
+        expect(suiteStartObject3).toBeDefined();
+        expect(suiteStartObject3.attributes).toEqual([]);
       });
     });
 
@@ -610,10 +617,18 @@ describe('utils script', () => {
         expect(testInfoObject).toEqual(expectedTestStartObject);
 
         test.tags = ['tag1', 'tag2', 'tag3'];
-        const testInfoObject2 = getTestStartObject(test);
+        // empty to test if attributes are added by default
+        const testInfoObject2 = getTestStartObject(test, {});
 
         expect(testInfoObject2).toBeDefined();
         expect(testInfoObject2).toEqual(expectedTestStartObject);
+
+        // disable attributes from cypress grep via config options
+        const options = { addCypressGrepAttributes: false };
+        const testInfoObject3 = getTestStartObject(test, options);
+
+        expect(testInfoObject3).toBeDefined();
+        expect(testInfoObject3.attributes).toEqual([]);
       });
     });
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -377,6 +377,42 @@ describe('utils script', () => {
         expect(suiteStartObject).toBeDefined();
         expect(suiteStartObject).toEqual(expectedSuiteStartObject);
       });
+
+      test('cypress grep tags: should return suite start with attributes from tags', () => {
+        const suite = {
+          id: 'suite1',
+          title: 'suite name',
+          description: 'suite description',
+          root: true,
+          titlePath: () => ['suite name'],
+          _testConfig: {
+            tags: 'tag1 tag2 tag3',
+          },
+        };
+        const expectedSuiteStartObject = {
+          id: 'suite1',
+          name: 'suite name',
+          type: 'suite',
+          startTime: currentDate,
+          description: 'suite description',
+          attributes: [{ value: 'tag1' }, { value: 'tag2' }, { value: 'tag3' }],
+          codeRef: 'test/example.spec.js/suite name',
+          parentId: undefined,
+        };
+
+        const suiteStartObject = getSuiteStartObject(suite, testFileName);
+
+        expect(suiteStartObject).toBeDefined();
+        expect(suiteStartObject).toEqual(expectedSuiteStartObject);
+
+        // test attributes from array of tags reusing previous check
+        // eslint-disable-next-line no-underscore-dangle
+        suite._testConfig.tags = ['tag1', 'tag2', 'tag3'];
+        const suiteStartObject2 = getSuiteStartObject(suite, testFileName);
+
+        expect(suiteStartObject2).toBeDefined();
+        expect(suiteStartObject2).toEqual(expectedSuiteStartObject);
+      });
     });
 
     describe('getSuiteEndObject', () => {
@@ -482,6 +518,48 @@ describe('utils script', () => {
         expect(testInfoObject).toBeDefined();
         expect(testInfoObject).toEqual(expectedTestInfoObject);
       });
+
+      test('cypress grep tags: should return test info with tags', () => {
+        const test = {
+          id: 'testId1',
+          title: 'test name',
+          parent: {
+            id: 'parentSuiteId',
+          },
+          state: 'passed',
+          titlePath: () => ['suite name', 'test name'],
+          _testConfig: {
+            unverifiedTestConfig: {
+              tags: 'tag1 tag2 tag3',
+            },
+          },
+        };
+
+        const expectedTestInfoObject = {
+          id: 'testId1',
+          title: 'test name',
+          status: 'passed',
+          parentId: 'parentSuiteId',
+          codeRef: 'test/example.spec.js/suite name/test name',
+          err: undefined,
+          testFileName,
+          tags: 'tag1 tag2 tag3',
+        };
+
+        const testInfoObject = getTestInfo(test, testFileName);
+
+        expect(testInfoObject).toBeDefined();
+        expect(testInfoObject).toEqual(expectedTestInfoObject);
+
+        // eslint-disable-next-line no-underscore-dangle
+        test.parent._testConfig = {
+          tags: 'tag1 tag2 tag3',
+        };
+        const testInfoObject2 = getTestInfo(test, testFileName);
+
+        expect(testInfoObject2).toBeDefined();
+        expect(testInfoObject2.tags).not.toBeDefined();
+      });
     });
 
     describe('getTestStartObject', () => {
@@ -506,6 +584,36 @@ describe('utils script', () => {
 
         expect(testInfoObject).toBeDefined();
         expect(testInfoObject).toEqual(expectedTestStartObject);
+      });
+
+      test('should return test start object with attributes from tags', () => {
+        const test = {
+          id: 'testId1',
+          title: 'test name',
+          parent: {
+            id: 'parentSuiteId',
+          },
+          codeRef: 'test/example.spec.js/suite name/test name',
+          tags: 'tag1 tag2 tag3',
+        };
+        const expectedTestStartObject = {
+          name: 'test name',
+          startTime: currentDate,
+          type: 'step',
+          codeRef: 'test/example.spec.js/suite name/test name',
+          attributes: [{ value: 'tag1' }, { value: 'tag2' }, { value: 'tag3' }],
+        };
+
+        const testInfoObject = getTestStartObject(test);
+
+        expect(testInfoObject).toBeDefined();
+        expect(testInfoObject).toEqual(expectedTestStartObject);
+
+        test.tags = ['tag1', 'tag2', 'tag3'];
+        const testInfoObject2 = getTestStartObject(test);
+
+        expect(testInfoObject2).toBeDefined();
+        expect(testInfoObject2).toEqual(expectedTestStartObject);
       });
     });
 


### PR DESCRIPTION
[cypress-grep](https://github.com/cypress-io/cypress/tree/develop/npm/grep#usage-overview) allows tagging and filtering tests. This is an attempt to automatically add tags as attributes for suites and tests. For this to work #141 is required as tests not executed by cypress-grep will be skipped.

When automatically adding attributes from tags, it helps organizing large suites without duplicating tags and attributes. Could potentially also help adding attributes without writing a lot of code to explicitly add via `cy.addAttributes`. 

Added an optional config option `addCypressGrepAttributes` to disable adding attributes automatically. Name is just a suggestion, could be changed if needed. See test cases as reference.

Sample usage from [tags-in-the-test-config-object](https://github.com/cypress-io/cypress/tree/develop/npm/grep#tags-in-the-test-config-object)
```typescript
it('works as an array', { tags: ['config', 'some-other-tag'] }, () => {
  expect(true).to.be.true
})

it('works as a string', { tags: 'config' }, () => {
  expect(true).to.be.true
})
```