### PR TITLE
Fix loosing ipc events before client is connected

### DIFF
--- a/lib/plugin/index.js
+++ b/lib/plugin/index.js
@@ -18,8 +18,35 @@ const ipc = require('node-ipc');
 const { connectIPCClient } = require('./ipcClient');
 const { IPC_EVENTS } = require('./../ipcEvents');
 
+let connected = false;
+
 const registerReportPortalPlugin = (on, config) => {
-  connectIPCClient(config);
+  let ipcCache = [];
+
+  const emit = (event, value) => {
+    if (connected && ipc && ipc.of && ipc.of.reportportal) {
+      ipc.of.reportportal.emit(event, value);
+    } else {
+      // cache events in case IPC connection in not yet established
+      // this will be re-emitted when IPC state changes to 'connect'
+      ipcCache.push({ event, value });
+    }
+  };
+
+  const ipcCallback = {
+    connected: () => {
+      connected = true;
+      ipcCache.forEach((element) => {
+        emit(element.event, element.value);
+      });
+      ipcCache = [];
+    },
+    disconnected: () => {
+      connected = false;
+    },
+  };
+
+  connectIPCClient(config, ipcCallback);
 
   on('task', {
     rp_Log(log) {

--- a/lib/plugin/ipcClient.js
+++ b/lib/plugin/ipcClient.js
@@ -23,7 +23,7 @@
 const ipc = require('node-ipc');
 const { IPC_EVENTS } = require('./../ipcEvents');
 
-const connectIPCClient = (config) => {
+const connectIPCClient = (config, callback) => {
   ipc.config.id = 'reportPortalReporter';
   ipc.config.retry = 1500;
   ipc.config.silent = true;
@@ -32,9 +32,11 @@ const connectIPCClient = (config) => {
     ipc.of.reportportal.on('connect', () => {
       ipc.log('***connected to reportportal***');
       ipc.of.reportportal.emit(IPC_EVENTS.CONFIG, config);
+      callback && callback.connected && callback.connected();
     });
     ipc.of.reportportal.on('disconnect', () => {
       ipc.log('disconnected from reportportal');
+      callback && callback.disconnected && callback.disconnected();
     });
   });
 };


### PR DESCRIPTION
When starting the plugin the IPC connection is established the events from Cypress will be emitted to. As establishing the IPC connection takes some time, events coming in before IPC client is connected might actually not be emitted and uploaded to Report Portal. This might happen if events are created in Cypress `before` hook.

This is a proof-of-concept implementation. Not sure if there is a better way of doing this with `NodeIPC.Client`. 

Anyone any thoughts?