### PR TITLE
Send log on test fail independently from screenshots

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -16,7 +16,7 @@
 
 const RPClient = require('@reportportal/client-javascript');
 
-const { entityType, logLevels } = require('./constants');
+const { entityType, logLevels, testItemStatuses } = require('./constants');
 const {
   getScreenshotAttachment,
   getTestStartObject,
@@ -27,6 +27,8 @@ const {
 
 const { createMergeLaunchLockFile, deleteMergeLaunchLockFile } = require('./mergeLaunchesUtils');
 const { mergeParallelLaunches } = require('./mergeLaunches');
+
+const { FAILED } = testItemStatuses;
 
 const promiseErrorHandler = (promise, message = '') =>
   promise.catch((err) => {
@@ -141,12 +143,24 @@ class Reporter {
     }
   }
 
+  sendLogOnFinishFailedItem(test, tempTestId) {
+    if (test.status === FAILED) {
+      const sendFailedLogPromise = this.client.sendLog(tempTestId, {
+        message: test.err,
+        level: logLevels.ERROR,
+        time: new Date().valueOf(),
+      }).promise;
+      promiseErrorHandler(sendFailedLogPromise, 'Fail to save error log');
+    }
+  }
+
   testEnd(test) {
     let testId = this.testItemIds.get(test.id);
     if (!testId) {
       this.testStart(test);
       testId = this.testItemIds.get(test.id);
     }
+    this.sendLogOnFinishFailedItem(test, testId);
     const testInfo = Object.assign({}, test, this.currentTestFinishParams);
     const finishTestItemPromise = this.client.finishTestItem(
       testId,
@@ -193,7 +207,7 @@ class Reporter {
       this.testItemIds.get(hook.parentId),
     );
     promiseErrorHandler(promise, 'Fail to start hook');
-
+    this.sendLogOnFinishFailedItem(hook, tempId);
     const finishHookPromise = this.client.finishTestItem(tempId, {
       status: hook.status,
       endTime: new Date().valueOf(),
@@ -281,16 +295,16 @@ class Reporter {
 
     const message = logMessage || `screenshot ${file.name}`;
 
-    const sendScreenshotsPromise = this.client.sendLog(
+    const sendScreenshotPromise = this.client.sendLog(
       tempItemId,
       {
         message,
         level,
-        time: new Date().valueOf(),
+        time: new Date(screenshotInfo.takenAt).valueOf(),
       },
       file,
     ).promise;
-    promiseErrorHandler(sendScreenshotsPromise, 'Fail to save screenshot.');
+    promiseErrorHandler(sendScreenshotPromise, 'Fail to save screenshot.');
   }
 }
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -21,6 +21,8 @@ const {
 } = require('./../lib/utils');
 const pjson = require('./../package.json');
 
+const sep = path.sep;
+
 const { RealDate, MockedDate, currentDate, getDefaultConfig } = require('./mock/mock');
 
 describe('utils script', () => {
@@ -47,7 +49,7 @@ describe('utils script', () => {
     });
 
     it('getScreenshotAttachment: should return attachment for absolute path', () => {
-      const testFile = '/example/screenshots/example.spec.js/suite name -- test name (failed).png';
+      const testFile = `${sep}example${sep}screenshots${sep}example.spec.js${sep}suite name -- test name (failed).png`;
       const expectedAttachment = {
         name: 'suite name -- test name (failed).png',
         type: 'image/png',
@@ -771,11 +773,11 @@ describe('utils script', () => {
 
   describe('getFixtureFolderPattern', () => {
     it('returns a glob pattern for fixtures folder', () => {
-      const specConfig = { fixturesFolder: 'cypress/fixtures' };
+      const specConfig = { fixturesFolder: `cypress${sep}fixtures` };
 
       const specArray = getFixtureFolderPattern(specConfig);
       expect(specArray).toHaveLength(1);
-      expect(specArray).toContain('cypress/fixtures/**/*');
+      expect(specArray).toContain(`cypress${sep}fixtures${sep}**${sep}*`);
     });
   });
   describe('getExcludeSpecPattern', () => {


### PR DESCRIPTION
@thomaswinkler FYI
I've reverted sending a separate test failure log because it's useful to see the entire error message in addition to the screenshot to analyze the results.
Also usually the error message is the target of [RP Analyzer](https://reportportal.io/docs/analysis/AutoAnalysisOfLaunches#create-an-analytical-base-in-the-elasticsearch).