### PR TITLE
Update attachments.js : Add timeout before resolve files

### DIFF
--- a/lib/utils/attachments.js
+++ b/lib/utils/attachments.js
@@ -50,7 +50,9 @@ const waitForFile = (
       const files = await glob(globFilePattern);
 
       if (files.length) {
-        resolve(files[0]);
+        setTimeout(() => {
+          resolve(files[0]);
+        }, timeout);
       } else if (totalTime >= timeout) {
         reject(new Error(`Timeout of ${timeout}ms reached, file ${globFilePattern} not found.`));
       } else {

--- a/lib/utils/attachments.js
+++ b/lib/utils/attachments.js
@@ -50,7 +50,7 @@ const waitForFile = (
       const files = await glob(globFilePattern);
 
       if (files.length) {
-          resolve(files[0]);
+        resolve(files[0]);
       } else if (totalTime >= timeout) {
         reject(new Error(`Timeout of ${timeout}ms reached, file ${globFilePattern} not found.`));
       } else {
@@ -69,29 +69,34 @@ const checkMoovAtom = (
 ) => {
   return new Promise((resolve, reject) => {
     let totalTime = 0;
-    function checkFile() {
+
+    const checkFile = () => {
       try {
         fs.readFile(mp4FilePath, (err, data) => {
           if (err) {
             return reject(new Error(`Error reading file: ${err.message}`));
           }
+
           if (data.includes('moov')) {
             return resolve(true);
-          } else if (totalTime >= timeout) {
+          }
+
+          if (totalTime >= timeout) {
             return reject(
               new Error(
-                `Timeout of ${timeout}ms reached, 'moov' atom not found in file ${mp4FilePath}.`
-              )
+                `Timeout of ${timeout}ms reached, 'moov' atom not found in file ${mp4FilePath}.`,
+              ),
             );
-          } else {
-            totalTime += interval;
-            setTimeout(checkFile, interval);
           }
+          totalTime += interval;
+          setTimeout(checkFile, interval);
+          return null;
         });
       } catch (error) {
         return reject(new Error(`Unexpected error: ${error.message}`));
       }
-    }
+      return null;
+    };
     checkFile();
   });
 };
@@ -119,7 +124,7 @@ const getVideoFile = async (
   }
 
   try {
-    const result = await checkMoovAtom(videoFilePath, timeout, interval);
+    await checkMoovAtom(videoFilePath, timeout, interval);
   } catch (e) {
     console.warn(e.message);
     return null;

--- a/lib/utils/attachments.js
+++ b/lib/utils/attachments.js
@@ -50,9 +50,7 @@ const waitForFile = (
       const files = await glob(globFilePattern);
 
       if (files.length) {
-        setTimeout(() => {
           resolve(files[0]);
-        }, timeout);
       } else if (totalTime >= timeout) {
         reject(new Error(`Timeout of ${timeout}ms reached, file ${globFilePattern} not found.`));
       } else {
@@ -63,6 +61,40 @@ const waitForFile = (
 
     checkFileExistence().catch(reject);
   });
+
+const checkMoovAtom = (
+  mp4FilePath,
+  timeout = DEFAULT_WAIT_FOR_FILE_TIMEOUT,
+  interval = DEFAULT_WAIT_FOR_FILE_INTERVAL,
+) => {
+  return new Promise((resolve, reject) => {
+    let totalTime = 0;
+    function checkFile() {
+      try {
+        fs.readFile(mp4FilePath, (err, data) => {
+          if (err) {
+            return reject(new Error(`Error reading file: ${err.message}`));
+          }
+          if (data.includes('moov')) {
+            return resolve(true);
+          } else if (totalTime >= timeout) {
+            return reject(
+              new Error(
+                `Timeout of ${timeout}ms reached, 'moov' atom not found in file ${mp4FilePath}.`
+              )
+            );
+          } else {
+            totalTime += interval;
+            setTimeout(checkFile, interval);
+          }
+        });
+      } catch (error) {
+        return reject(new Error(`Unexpected error: ${error.message}`));
+      }
+    }
+    checkFile();
+  });
+};
 
 const getVideoFile = async (
   specFileName,
@@ -86,6 +118,13 @@ const getVideoFile = async (
     return null;
   }
 
+  try {
+    const result = await checkMoovAtom(videoFilePath, timeout, interval);
+  } catch (e) {
+    console.warn(e.message);
+    return null;
+  }
+
   return {
     name: fileName,
     type: 'video/mp4',
@@ -97,4 +136,5 @@ module.exports = {
   getScreenshotAttachment,
   getVideoFile,
   waitForFile,
+  checkMoovAtom,
 };


### PR DESCRIPTION
This changes resolves #202 by adding timeout from option for video file readiness.

Cypress video processing may take extra time after the spec is complete, so add a timeout to wait for the video file readiness.
