### PR TITLE
Upgrade node-ipc from 9.1.1 (DBAD) to 9.1.5 (MIT)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@reportportal/agent-js-cypress",
-      "version": "5.4.0",
+      "version": "5.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
@@ -17,7 +17,7 @@
         "glob": "^9.3.5",
         "minimatch": "^3.1.2",
         "mocha": "^10.2.0",
-        "node-ipc": "9.1.1"
+        "node-ipc": "9.1.5"
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",
@@ -2978,6 +2978,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/easy-stack/-/easy-stack-1.0.1.tgz",
       "integrity": "sha512-wK2sCs4feiiJeFXn3zvY0p41mdU5VUgbgs1rNsc/y5ngFUijdWd+iIN8eoyuZHKB8xN6BL4PdWmzqFmxNg6V2w==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -5523,19 +5524,21 @@
       }
     },
     "node_modules/js-message": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/js-message/-/js-message-1.0.5.tgz",
-      "integrity": "sha512-hTqHqrm7jrZ+iN93QsKcNOTSgX3F+2NSgdnF+xvf8FfhC2MPqYRzzgXQ1LlhfyIzPTS6hL6Zea0/gIb6hktkHw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/js-message/-/js-message-1.0.7.tgz",
+      "integrity": "sha512-efJLHhLjIyKRewNS9EGZ4UpI8NguuL6fKkhRxVuMmrGV2xN/0APGdQYwLFky5w9naebSZ0OwAGp0G6/2Cg90rA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.6.0"
       }
     },
     "node_modules/js-queue": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/js-queue/-/js-queue-2.0.0.tgz",
-      "integrity": "sha512-SW0rTTG+TBPVD1Kp6HtnOr9kX3//EWA6qMlP2Y/WxbKsSNCBuJbWv3EDB5noKJBEkHYi2mDY+xqMn4Y0QHyjyg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/js-queue/-/js-queue-2.0.2.tgz",
+      "integrity": "sha512-pbKLsbCfi7kriM3s1J4DDCo7jQkI58zPLHi0heXPzPlj0hjUsm+FesPUbE0DSbIVIK503A36aUBoCN7eMFedkA==",
+      "license": "MIT",
       "dependencies": {
-        "easy-stack": "^1.0.0"
+        "easy-stack": "^1.0.1"
       },
       "engines": {
         "node": ">=1.0.0"
@@ -6069,16 +6072,17 @@
       "dev": true
     },
     "node_modules/node-ipc": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/node-ipc/-/node-ipc-9.1.1.tgz",
-      "integrity": "sha512-FAyICv0sIRJxVp3GW5fzgaf9jwwRQxAKDJlmNFUL5hOy+W4X/I5AypyHoq0DXXbo9o/gt79gj++4cMr4jVWE/w==",
+      "version": "9.1.5",
+      "resolved": "https://registry.npmjs.org/node-ipc/-/node-ipc-9.1.5.tgz",
+      "integrity": "sha512-Ws+2FpHK50qrlYNHy0JAkkiKKUoJE+eqxwO1LNGf28YI4+73zK3jmn7dMHUDpHHPrjeeO7qUq+RsuTSLAxvDCg==",
+      "license": "MIT",
       "dependencies": {
         "event-pubsub": "4.3.0",
-        "js-message": "1.0.5",
-        "js-queue": "2.0.0"
+        "js-message": "1.0.7",
+        "js-queue": "2.0.2"
       },
       "engines": {
-        "node": ">=4.0.0"
+        "node": ">=8.0.0"
       }
     },
     "node_modules/node-releases": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "glob": "^9.3.5",
     "minimatch": "^3.1.2",
     "mocha": "^10.2.0",
-    "node-ipc": "9.1.1",
+    "node-ipc": "9.1.5",
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
     "ffmpeg": "^0.0.4",
     "ffprobe-static": "^3.1.0",


### PR DESCRIPTION
The DBAD license is not Apache-2.0 compatible.

Therefore upgrade node-ipc
from 9.1.1 with DBAD license
to 9.1.5 with MIT license.

* https://www.npmjs.com/package/node-ipc/v/9.1.1
* https://www.npmjs.com/package/node-ipc/v/9.1.5